### PR TITLE
Reduce Logging

### DIFF
--- a/tap_partnerize/client.py
+++ b/tap_partnerize/client.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Iterable
 
 import requests
 import csv
-import logging
+# import logging
 import io
 from singer_sdk.authenticators import BasicAuthenticator
 from singer_sdk.streams import RESTStream
@@ -154,7 +154,7 @@ class PartnerizeStream(RESTStream):
         f = io.StringIO(response.text)
         for count, row in enumerate(csv.DictReader(f)):
             page_date = row.get("conversion_date")
-            logging.info(f"Retrieved {count+1} records for data chunk {page_date}")
+#             logging.info(f"Retrieved {count+1} records for data chunk {page_date}")
             yield row
 
     def post_process(self, row: dict, context: dict | None = None) -> dict | None:


### PR DESCRIPTION
The current level of logging results in a message for each request, which is over 1 million logged events for our current use case, and significantly slows down the stream. Recommend suppressing these logs for now to see if that improves performance.