### PR TITLE
[codex] Handle non-numeric Partnerize delivery cost metadata

### DIFF
--- a/tap_partnerize/client.py
+++ b/tap_partnerize/client.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
-import requests
 import csv
-# import logging
 import io
+import logging
+
+import requests
 from singer_sdk.authenticators import BasicAuthenticator
 from singer_sdk.streams import RESTStream
 from singer_sdk.pagination import BaseAPIPaginator
@@ -19,6 +20,7 @@ from datetime import datetime, timedelta
 
 _Auth = Callable[[requests.PreparedRequest], requests.PreparedRequest]
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
+LOGGER = logging.getLogger(__name__)
 
 
 class DayChunkPaginator(BaseAPIPaginator):
@@ -170,7 +172,21 @@ class PartnerizeStream(RESTStream):
         row["meta_conversion_gross_value"] = set_none_or_cast(row.get("meta_conversion_gross_value"), float)
         row["item_value"] = set_none_or_cast(row.get("item_value"), float)
         row["conversion_lag"] = set_none_or_cast(row.get("conversion_lag"), int)
-        row["meta_conversion_delivery_cost"] = set_none_or_cast(row.get("meta_conversion_delivery_cost"), float)
+        delivery_cost = row.get("meta_conversion_delivery_cost")
+        try:
+            row["meta_conversion_delivery_cost"] = set_none_or_cast(delivery_cost, float)
+        except (TypeError, ValueError):
+            LOGGER.warning(
+                "Unable to parse meta_conversion_delivery_cost=%r as float; "
+                "setting None. conversion_id=%r conversion_item_id=%r "
+                "publisher_reference=%r advertiser_reference=%r",
+                delivery_cost,
+                row.get("conversion_id"),
+                row.get("conversion_item_id"),
+                row.get("publisher_reference"),
+                row.get("advertiser_reference"),
+            )
+            row["meta_conversion_delivery_cost"] = None
         row["creative_type"] = set_none_or_cast(row.get("creative_type"), int)
         row["item_publisher_commission"] = set_none_or_cast(row.get("item_publisher_commission"), float)
         row["publisher_commission"] = set_none_or_cast(row.get("publisher_commission"), float)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,53 @@
+"""Tests for Partnerize response processing."""
+
+import logging
+
+import pytest
+
+from tap_partnerize.client import PartnerizeStream
+
+
+def processed_conversion_row(**overrides):
+    row = {
+        "meta_conversion_gross_value": "24.50",
+        "item_value": "20.00",
+        "conversion_lag": "1",
+        "meta_conversion_delivery_cost": "4.95",
+        "creative_type": "2",
+        "item_publisher_commission": "1.25",
+        "publisher_commission": "1.25",
+        "value": "20.00",
+        "quantity": "1",
+        "meta_conversion_container_version": "3",
+        "conversion_id": "conversion-123",
+        "conversion_item_id": "item-456",
+        "publisher_reference": "pub-ref",
+        "advertiser_reference": "adv-ref",
+    }
+    row.update(overrides)
+
+    stream = PartnerizeStream.__new__(PartnerizeStream)
+    return stream.post_process(row)
+
+
+def test_post_process_keeps_numeric_delivery_cost():
+    row = processed_conversion_row(meta_conversion_delivery_cost="4.95")
+
+    assert row["meta_conversion_delivery_cost"] == 4.95
+
+
+def test_post_process_ignores_non_numeric_delivery_cost(caplog):
+    caplog.set_level(logging.WARNING, logger="tap_partnerize.client")
+
+    row = processed_conversion_row(meta_conversion_delivery_cost="Evening")
+
+    assert row["meta_conversion_delivery_cost"] is None
+    assert "meta_conversion_delivery_cost" in caplog.text
+    assert "Evening" in caplog.text
+    assert "conversion-123" in caplog.text
+    assert "item-456" in caplog.text
+
+
+def test_post_process_still_raises_for_other_non_numeric_fields():
+    with pytest.raises(ValueError):
+        processed_conversion_row(item_value="Standard")


### PR DESCRIPTION
## Problem
Partnerize can return non-numeric shipping or service labels, such as `Evening` or `Standard`, in `meta_conversion_delivery_cost`. The tap hard-cast that field to `float`, which aborts the pipeline even though this metadata field is not used for downstream earnings or revenue calculations.

## Solution
Keep the existing numeric schema contract, but treat non-numeric `meta_conversion_delivery_cost` values as bad optional metadata: log the field value and identifying row references, then emit `None` for that field. Other numeric fields still raise on invalid values.

## Validation
- `uv run --python /usr/bin/python3 --with pytest==7.2.1 --with singer-sdk==0.21.0 --with requests --with setuptools==68.2.2 pytest tests/test_client.py` -> 3 passed
- `git diff --cached --check` -> no whitespace errors

Full `pytest` collection is blocked in this checkout because `.secrets/config.json` is missing for the existing SDK tests.
