### PR TITLE
Null non-numeric gross_value; modernize basic auth

### DIFF
--- a/tap_partnerize/client.py
+++ b/tap_partnerize/client.py
@@ -10,7 +10,7 @@ import io
 import logging
 
 import requests
-from singer_sdk.authenticators import BasicAuthenticator
+from requests.auth import HTTPBasicAuth
 from singer_sdk.streams import RESTStream
 from singer_sdk.pagination import BaseAPIPaginator
 from requests import Response
@@ -88,14 +88,13 @@ class PartnerizeStream(RESTStream):
         return self.config.get("start_date", "")
 
     @property
-    def authenticator(self) -> BasicAuthenticator:
+    def authenticator(self) -> HTTPBasicAuth:
         """Return a new authenticator object.
 
         Returns:
             An authenticator instance.
         """
-        return BasicAuthenticator.create_for_stream(
-            self,
+        return HTTPBasicAuth(
             username=self.config.get("username", ""),
             password=self.config.get("password", ""),
         )
@@ -172,7 +171,21 @@ class PartnerizeStream(RESTStream):
         """
         if row.get("meta_conversion_gross_value") == "undefined" or row.get("meta_item_product_id") == "undefined" or row.get("job_id"):
             return None
-        row["meta_conversion_gross_value"] = set_none_or_cast(row.get("meta_conversion_gross_value"), float)
+        gross_value = row.get("meta_conversion_gross_value")
+        try:
+            row["meta_conversion_gross_value"] = set_none_or_cast(gross_value, float)
+        except (TypeError, ValueError):
+            LOGGER.warning(
+                "Dropping row with non-numeric meta_conversion_gross_value=%r. "
+                "conversion_id=%r conversion_item_id=%r "
+                "publisher_reference=%r advertiser_reference=%r",
+                gross_value,
+                row.get("conversion_id"),
+                row.get("conversion_item_id"),
+                row.get("publisher_reference"),
+                row.get("advertiser_reference"),
+            )
+            return None
         row["item_value"] = set_none_or_cast(row.get("item_value"), float)
         row["conversion_lag"] = set_none_or_cast(row.get("conversion_lag"), int)
         delivery_cost = row.get("meta_conversion_delivery_cost")

--- a/tap_partnerize/client.py
+++ b/tap_partnerize/client.py
@@ -176,8 +176,8 @@ class PartnerizeStream(RESTStream):
             row["meta_conversion_gross_value"] = set_none_or_cast(gross_value, float)
         except (TypeError, ValueError):
             LOGGER.warning(
-                "Dropping row with non-numeric meta_conversion_gross_value=%r. "
-                "conversion_id=%r conversion_item_id=%r "
+                "Unable to parse meta_conversion_gross_value=%r as float; "
+                "setting None. conversion_id=%r conversion_item_id=%r "
                 "publisher_reference=%r advertiser_reference=%r",
                 gross_value,
                 row.get("conversion_id"),
@@ -185,7 +185,7 @@ class PartnerizeStream(RESTStream):
                 row.get("publisher_reference"),
                 row.get("advertiser_reference"),
             )
-            return None
+            row["meta_conversion_gross_value"] = None
         row["item_value"] = set_none_or_cast(row.get("item_value"), float)
         row["conversion_lag"] = set_none_or_cast(row.get("conversion_lag"), int)
         delivery_cost = row.get("meta_conversion_delivery_cost")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -53,12 +53,13 @@ def test_post_process_still_raises_for_other_non_numeric_fields():
         processed_conversion_row(item_value="Standard")
 
 
-def test_post_process_drops_row_with_non_numeric_gross_value(caplog):
+def test_post_process_ignores_non_numeric_gross_value(caplog):
     caplog.set_level(logging.WARNING, logger="tap_partnerize.client")
 
     row = processed_conversion_row(meta_conversion_gross_value="false")
 
-    assert row is None
+    assert row["meta_conversion_gross_value"] is None
+    assert row["item_value"] == 20.00
     assert "meta_conversion_gross_value" in caplog.text
     assert "false" in caplog.text
     assert "conversion-123" in caplog.text

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -51,3 +51,27 @@ def test_post_process_ignores_non_numeric_delivery_cost(caplog):
 def test_post_process_still_raises_for_other_non_numeric_fields():
     with pytest.raises(ValueError):
         processed_conversion_row(item_value="Standard")
+
+
+def test_post_process_drops_row_with_non_numeric_gross_value(caplog):
+    caplog.set_level(logging.WARNING, logger="tap_partnerize.client")
+
+    row = processed_conversion_row(meta_conversion_gross_value="false")
+
+    assert row is None
+    assert "meta_conversion_gross_value" in caplog.text
+    assert "false" in caplog.text
+    assert "conversion-123" in caplog.text
+    assert "item-456" in caplog.text
+
+
+def test_post_process_keeps_numeric_gross_value():
+    row = processed_conversion_row(meta_conversion_gross_value="42.10")
+
+    assert row["meta_conversion_gross_value"] == 42.10
+
+
+def test_post_process_keeps_empty_gross_value():
+    row = processed_conversion_row(meta_conversion_gross_value="")
+
+    assert row["meta_conversion_gross_value"] is None


### PR DESCRIPTION
## Problem
Two follow-ups to recent meltano-side failures:

1. After PR #4 fixed `meta_conversion_delivery_cost`, the same shape of bug surfaced on `meta_conversion_gross_value` — Partnerize returned the literal string `"false"`, blowing up `post_process` with `ValueError: could not convert string to float: 'false'`.
2. singer-sdk 0.49 (pulled in by PR #5) emits `BasicAuthenticator is deprecated and will be removed by 2026-01-01. Use 'requests.auth.HTTPBasicAuth' instead.` — the deadline has already passed and the next singer-sdk bump will break the tap.

## Solution
- `meta_conversion_gross_value`: catch `TypeError`/`ValueError` and **null the field + log** (mirror PR #4's pattern). Investigation showed:
  - The field is empty in 100% of current API rows (10,381/10,381 sampled across vox + nym publishers).
  - The dbt staging model in `data-dbt` (`stg__partnerize_ecommerce_earnings.sql`) never references it — downstream `revenue` is sourced from `item_value`, `earnings` from `item_publisher_commission`.
  - The transient `"false"` that triggered the failure is no longer present in the API.
  - Given the field is unused downstream and bad values are rare, nulling preserves the row's real `item_value`/commission contributions; dropping would needlessly throw those away.
- Replace `singer_sdk.authenticators.BasicAuthenticator.create_for_stream(...)` with `requests.auth.HTTPBasicAuth(...)` per the deprecation guidance.

## Validation
- `uv run --python 3.12 --with pytest --with singer-sdk==0.49.1 --with requests pytest tests/test_client.py -v -p no:singer_testing` → 6 passed (3 existing + 3 new covering numeric kept, empty → None, non-numeric → null with warning + sibling fields preserved)
- Imports + authenticator type smoke-tested under singer-sdk 0.49.1

(`-p no:singer_testing` is needed locally because `tests/conftest.py` registers the singer plugin manually and 0.49 also auto-registers it via entry points; that's a pre-existing conftest issue, separate from this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)